### PR TITLE
Add service auto-restart

### DIFF
--- a/debian/zabbix-cachet.service
+++ b/debian/zabbix-cachet.service
@@ -5,6 +5,8 @@ Requires=network.target
 
 [Service]
 Type=simple
+Restart=on-failure
+RestartSec=5
 ExecStart=/usr/bin/zabbix-cachet
 Environment=CONFIG_FILE=/etc/zabbix-cachet.yml
 


### PR DESCRIPTION
Restart the service automatically if it exits in failure.  This will prevent simple misconfigs on the Zabbix Services side or some other error from killing the entire service. 