### PR TITLE
Update supported zabbix and Cachet versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ items of services that is exported to Cachet and Cachet`s API key.
 ![Cachet Components](https://cloud.githubusercontent.com/assets/8394059/14298058/c5c8b806-fb93-11e5-83f6-ff32aeb5fb4d.png)
 
 # Requirements
-* Cachet 2.2, 2.3
-* Zabbix 2.2, 2.4, 3.0, 3.2, 4.0
+* Cachet 2.2, 2.3, 2.4
+* Zabbix 2.2, 2.4, 3.0, 3.2, 4.0, 4.2
 * python 2.7+
 
 # Installation


### PR DESCRIPTION
Hi,
I succesfully tested it under Zabbix ver: 4.2.8. Cachet ver: 2.4.0-dev.
I added them to the README as supported versions.