### PR TITLE
Fix get_service on Zabbix 6+

### DIFF
--- a/src/zabbix_cachet/zabbix.py
+++ b/src/zabbix_cachet/zabbix.py
@@ -230,8 +230,12 @@ class Zabbix:
                 raise ZabbixCachetException(f'Can not find uniq "{root_name}" service in Zabbix')
             monitor_services = self._init_zabbix_it_service(root_service[0]).children
         else:
-            # TODO: Add support after 6.0
-            if self.version_major < 6:
+            if self.version_major >= 6:
+                services = self.get_service()
+                for i in services:
+                    if len(i['children']) > 0:
+                        monitor_services.append(self._init_zabbix_it_service(i))
+            elif self.version_major < 6:
                 services = self.get_service()
                 for i in services:
                     # Do not proceed non-root services directly


### PR DESCRIPTION
Hi.

I recently updated Zabbix 5.0 to 7.0 and found that zabbix-cachet 2.1.4 doesn't seem to work properly.

I found that get_service in zabbix.py lacks support for 6.0+.

After modifying it, it works fine now.